### PR TITLE
Add prepublish npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 This package acts as a wrapper around the VS Code File Downloader extension, which exposes an API that allows other
 extensions to download and manage binary dependencies.
 
+Useful links:
+- VS Code Extension: https://marketplace.visualstudio.com/items?itemName=mindaro-dev.file-downloader
+- VS Code Extension Source: https://github.com/microsoft/vscode-file-downloader 
+- Package Source: https://github.com/microsoft/vscode-file-downloader-api
+
 ## Setup
 
 Place the following in your VS Code extension's `package.json` file:
 
 ```json
 "extensionDependencies": [
-    "mindaro.file-downloader"
+    "mindaro-dev.file-downloader"
 ]
 ```
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "main": "./out/index.js",
     "scripts": {
         "compile": "tsc -p ./",
-        "lint": "eslint src --ext ts"
+        "lint": "eslint src --ext ts",
+        "prepublish": "npm run compile"
     },
     "author": "mindaro",
     "license": "MIT",

--- a/src/ExtensionHelper.ts
+++ b/src/ExtensionHelper.ts
@@ -9,7 +9,7 @@ export default class ExtensionHelper {
 
     public async getApi(): Promise<FileDownloader> {
         if (this._extension == null) {
-            const extension = vscode.extensions.getExtension(`mindaro.file-downloader`);
+            const extension = vscode.extensions.getExtension(`mindaro-dev.file-downloader`);
             if (extension == null) {
                 throw new Error(`Failed to get File Downloader VS Code extension.`);
             }


### PR DESCRIPTION
- Fixes issue where compiled files weren't published after a clean build
- Added useful links to the README
- Changed extension publisher ID to `mindaro-dev` to reflect https://marketplace.visualstudio.com/items?itemName=mindaro-dev.file-downloader