### PR TITLE
Add ability to skip aggressive vscode.Uri encoding

### DIFF
--- a/src/FileDownloader.ts
+++ b/src/FileDownloader.ts
@@ -38,6 +38,11 @@ export interface FileDownloadSettings {
      * }
      */
     headers?: Record<string, string | number | boolean> | undefined;
+    /**
+     * Whether to skip aggressive encoding on the URI, as `vscode.Uri.toString()` normally results in `&` and `=` becoming encoded.
+     * @default false
+     */
+    skipEncoding?: boolean
 }
 
 export default interface FileDownloader {


### PR DESCRIPTION
This is related to a bug present in `mindaro-dev.file-downloader`: https://github.com/microsoft/vscode-file-downloader/issues/56, and the relevant pull request to fix it: https://github.com/microsoft/vscode-file-downloader/pull/57

When trying to use this extension to download any file through a URL containing query parameters, the Uri is too aggressively encoded resulting in a 400 Bad Request (and no file downloaded).

A good example:
Original URL: `http://localhost:8081/service/rest/v1/search/assets/download?group=org.osgi&name=org.osgi.core&version=4.3.1&maven.extension=jar&maven.classifier`
when encoded, becomes
`http://localhost:8081/service/rest/v1/search/assets/download?group%3Dorg.osgi%26name%3Dorg.osgi.core%26version%3D4.3.1%26maven.extension%3Djar%26maven.classifier`, resulting in a bad request since the query parameters were incorrectly encoded.

This is due to a change in how `vscode.Uri.toString()` works, where an optional parameter was added that allowed inputted URLs to bypass aggressive encoding (since too many extensions depended on the over-aggressive encoding functionality). However, this breaks query parameters as `&` and `=` are encoded, causing URLs to break.

`vscode.Uri.toString(true)` bypasses this aggressive encoding and allows URLs with query parameters to work.

The issue in specific lies in `FileDownloader.ts` on line 118:
```
const downloadStream: Readable = await this._requestHandler.get(
                url.toString(), // right here is the bug, this should be url.toString(true)
                timeoutInMs,
                retries,
                retryDelayInMs,
                headers,
                cancellationToken,
                onDownloadProgressChange
            );
```

There is already a PR out for fixing this bug: https://github.com/microsoft/vscode-file-downloader/pull/57, however the changes also need to be mirrored to the API so that Typescript programs can take advantage of the new optional parameter. This PR mirrors the necessary changes.